### PR TITLE
Added check for when defaults[key] has a value but source[key] is null

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,9 @@ const diff = function (defaults, source) {
 
       } else {
 
-        if (typeof defaults[ key ] === 'undefined') {
+        if ((typeof defaults[ key ] === 'undefined') ||
+            (value === null && defaults[ key ] !== null)) {
+
           result[ key ] = value
 
         } else {


### PR DESCRIPTION
Previously it would only detect if defaults[key] was null and source[key] was not, but with this fix it will also detect if defaults[key] has a value but source[key] does not.

This is important if I want to track changes to an object.
For example, say an object looks like this: `{a: 'a', b: 'b'}`
Then I change it to: `{a: 'b', b: 'b'}`
So far, so good, I will get a diff that looks like this: `{a: 'b'}`
But what if I then do this: `{a: null, b: 'b', c: 'c'}` ?
This would previously give a diff that looked like this: `{c: 'c'}`
Notice how `a: null` was not included at all.
With this patch that same diff would look like: `{a: null, c: 'c'}`